### PR TITLE
Allow multiple errors in case of (json) schema validation

### DIFF
--- a/docs/http-body.md
+++ b/docs/http-body.md
@@ -27,30 +27,30 @@ For example:
 
 Aside from the standardized properties above, the RFC7807 spec also allows for custom properties. The following extra properties are sometimes used on publiq APIs to provide more information in specific situations.
 
-### jsonPointer
+### schemaErrors
 
-In some cases error responses can include a `jsonPointer` property that conforms to the [RFC6901](https://datatracker.ietf.org/doc/html/rfc6901) standard. This pointer indicates which specific JSON property inside the request body was invalid or caused a problem. It is especially helpful when one specific item inside a list caused an issue, because you can then ask your end user to correct it or leave it out.
+In the case of validation of JSON bodies in requests, error responses can include multiple validation errors at the same time in a `schemaErrors` property. 
 
-For example given the following JSON body in the request:
+This property will contain a list with objects that have a `jsonPointer` that conforms to the [RFC6901](https://datatracker.ietf.org/doc/html/rfc6901) standard. This pointer indicates which specific JSON property inside the request body was invalid or caused a problem. 
 
-```json
-{
-  "uitpasNumbers": [
-    "0900000905506",
-    "129876542345678987633456434567", // invalid
-    "0000100038306",
-  ]
-}
-```
+The objects also contain an `error` property with a human-readable (but often technical) explanation of why that specific part of the given JSON is invalid.
 
-The error response can pinpoint the problematic property value like this:
+For example:
 
 ```json
 {
-  "type": "https://api.publiq.be/probs/uitpas/invalid-uitpasnumber",
-  "title": "UiTPAS number invalid",
-  "detail": "UiTPAS numbers must be exactly 13 digits.",
+  "type": "https://api.publiq.be/probs/body/invalid-data",
+  "title": "Invalid body data",
   "status": "400",
-  "jsonPointer": "/uitpasNumbers/1" // Indicates the problematic property value
+  "schemaErrors": [
+    {
+      "jsonPointer": "/tariffId",
+      "error": "Required property (tariffId) missing."
+    },
+    {
+      "jsonPointer": "/numberOfTickets",
+      "error": "The data (string) must match the type: integer"
+    },
+  ]
 }
 ```

--- a/docs/type-body.md
+++ b/docs/type-body.md
@@ -26,4 +26,4 @@ The body you included (typically JSON) has an invalid syntax and cannot be parse
 -   **Title**: `Invalid body data`
 -   **Status**: `400`
 
-The body you included (typically JSON) has invalid or missing properties. The problem detail should contain more info about what property specifically, and in some cases a [jsonPointer](./http-body.md#jsonPointer) may be included.
+The body you included (typically JSON) has invalid or missing properties. The response should also either include a `detail` with more info about the validation error, or a [schemaErrors](./http-body.md#schemaErrors) property with a list of one or more schema validation problems.

--- a/models/Error.json
+++ b/models/Error.json
@@ -1,0 +1,50 @@
+{
+  "title": "Error",
+  "type": "object",
+  "description": "RFC7807 error model for all publiq APIs.",
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "A URI reference that identifies the problem type."
+    },
+    "title": {
+      "type": "string",
+      "description": "A short, human-readable summary of the problem type."
+    },
+    "status": {
+      "type": "integer",
+      "description": "The HTTP status code."
+    },
+    "detail": {
+      "type": "string",
+      "description": "A human-readable explanation specific to this occurrence of the problem. "
+    },
+    "schemaErrors": {
+      "type": "array",
+      "description": "A list of one or more schema validation errors (usually related to problems in the request body).",
+      "items": {
+        "type": "object",
+        "properties": {
+          "jsonPointer": {
+            "type": "string",
+            "format": "json-pointer",
+            "description": "RFC6901 compliant pointer that indicates what property/value was invalid."
+          },
+          "error": {
+            "type": "string",
+            "description": "A human-readable (but often technical) reason why the property was invalid."
+          }
+        },
+        "required": [
+          "jsonPointer",
+          "error"
+        ]
+      }
+    }
+  },
+  "required": [
+    "type",
+    "title",
+    "status"
+  ]
+}


### PR DESCRIPTION
### Added

- `schemaErrors` property to RFC7807 extensions in our docs
- `Error` model that we can share across projects using `"$ref": "https://raw.githubusercontent.com/cultuurnet/stoplight-docs-errors/main/models/Error.json"` in OpenAPI files (after this PR is merged) instead of having to duplicate it in every OpenAPI file like we do now

### Removed

- `jsonPointer` property from RFC7807 extensions in our docs

