### PR TITLE
Improve/fix error types

### DIFF
--- a/docs/type-header.md
+++ b/docs/type-header.md
@@ -12,7 +12,11 @@ This page contains an overview of all possible error types inside the `https://a
 
 A required header is missing. More info on what header specifically can be found in the `detail` property of the response.
 
-Note: APIs should only use this error type if a more specific type is not available. For example, `https://api.publiq.be/probs/auth/unauthorized` can be used if the `Authorization` header is missing.
+<!-- theme: warning -->
+
+> **Note to API designers**
+>
+> APIs should only use this error type if a more specific type is not available. For example, `https://api.publiq.be/probs/auth/unauthorized` can be used if the `Authorization` header is missing.
 
 ## invalid
 
@@ -22,7 +26,11 @@ Note: APIs should only use this error type if a more specific type is not availa
 
 The value of a given header is invalid. More info on what header specifically can be found in the `detail` property of the response.
 
-Note: APIs should only use this error type if a more specific type is not available. For example, `https://api.publiq.be/probs/auth/unauthorized` can be used if the `Authorization` header is invalid.
+<!-- theme: warning -->
+
+> **Note to API designers**
+>
+> APIs should only use this error type if a more specific type is not available. For example, `https://api.publiq.be/probs/auth/unauthorized` can be used if the `Authorization` header is invalid.
 
 ## not-acceptable
 

--- a/docs/type-header.md
+++ b/docs/type-header.md
@@ -28,8 +28,22 @@ The value of a given header is invalid. More info on what header specifically ca
 
 This error is returned if the request to the API included an `Accept` header with a content-type that the API does not support, and the API is unwilling or unable to return a default content-type instead.
 
-For example, you might be doing a request with `Accept: application/xml` while the API does not support XML and does not want to return a default format like JSON instead. In this case the API will return this error.
+For example, you might be sending a request with `Accept: application/xml` while the API does not support XML and does not want to return a default format like JSON instead. In this case the API will return this error.
 
 To fix this error, do not use an `Accept` header in your requests or set it to a content-type that the API supports (most often `application/json` and/or `application/json+ld`).
 
 For more info, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406
+
+## unsupported-media-type
+
+-   **Type:** `https://api.publiq.be/probs/header/unsupported-media-type`
+-   **Title**: `Unsupported Media Type`
+-   **Status**: `415`
+
+This error is returned if the request to the API included a `Content-Type` header with a value that the API does not support.
+
+For example, you might be sending a request with `Content-Type: application/xml` while the API does not support XML.
+
+To fix this error, use a `Content-Type` (and a request body in that format) that is supported by the API.
+
+For more info, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415

--- a/docs/type-header.md
+++ b/docs/type-header.md
@@ -16,7 +16,7 @@ A required header is missing. More info on what header specifically can be found
 
 > **Note to API designers**
 >
-> APIs should only use this error type if a more specific type is not available. For example, `https://api.publiq.be/probs/auth/unauthorized` can be used if the `Authorization` header is missing.
+> APIs should only use this error type if a more specific type is not available. For example, `https://api.publiq.be/probs/auth/unauthorized` must be used if the `Authorization` header is missing.
 
 ## invalid
 
@@ -30,7 +30,7 @@ The value of a given header is invalid. More info on what header specifically ca
 
 > **Note to API designers**
 >
-> APIs should only use this error type if a more specific type is not available. For example, `https://api.publiq.be/probs/auth/unauthorized` can be used if the `Authorization` header is invalid.
+> APIs should only use this error type if a more specific type is not available. For example, `https://api.publiq.be/probs/auth/unauthorized` must be used if the `Authorization` header is invalid.
 
 ## not-acceptable
 

--- a/docs/type-header.md
+++ b/docs/type-header.md
@@ -12,6 +12,8 @@ This page contains an overview of all possible error types inside the `https://a
 
 A required header is missing. More info on what header specifically can be found in the `detail` property of the response.
 
+Note: APIs should only use this error type if a more specific type is not available. For example, `https://api.publiq.be/probs/auth/unauthorized` can be used if the `Authorization` header is missing.
+
 ## invalid
 
 -   **Type:** `https://api.publiq.be/probs/header/invalid`
@@ -19,6 +21,8 @@ A required header is missing. More info on what header specifically can be found
 -   **Status**: `400`
 
 The value of a given header is invalid. More info on what header specifically can be found in the `detail` property of the response.
+
+Note: APIs should only use this error type if a more specific type is not available. For example, `https://api.publiq.be/probs/auth/unauthorized` can be used if the `Authorization` header is invalid.
 
 ## not-acceptable
 

--- a/docs/type-method.md
+++ b/docs/type-method.md
@@ -1,0 +1,13 @@
+# Method
+
+This page contains an overview of all possible error types inside the `https://api.publiq.be/probs/method/` namespace that can be returned by publiq's APIs.
+
+> APIs can also use their own types for errors. The types below are used in situations where an API has no specific type for an error related to the requested HTTP method.
+
+## not-allowed
+
+-   **Type:** `https://api.publiq.be/probs/method/not-allowed`
+-   **Title**: `Method not allowed`
+-   **Status**: `405`
+
+The resource you requested exists, but the HTTP method you are trying to use is not supported. For example the resource may support `GET` but not `PUT`. The `detail` should contain the supported methods on the requested URL.

--- a/docs/type-url.md
+++ b/docs/type-url.md
@@ -15,14 +15,6 @@ The URL you requested is not available. Possible causes include:
 -   The endpoint does not exist
 -   An id or slug of a resource in the path does not exist or is invalid
 
-## method-not-allowed
-
--   **Type:** `https://api.publiq.be/probs/url/method-not-allowed`
--   **Title**: `Method not allowed`
--   **Status**: `405`
-
-The URL you requested exists, but the method you are trying to use is not supported. For example the endpoint may support `GET` but not `PUT`. The `detail` should contain the supported methods on the requested URL.
-
 ## query-parameter-missing
 
 -   **Type:** `https://api.publiq.be/probs/url/query-parameter-missing`

--- a/docs/type-url.md
+++ b/docs/type-url.md
@@ -27,7 +27,7 @@ The URL you requested exists, but the method you are trying to use is not suppor
 
 -   **Type:** `https://api.publiq.be/probs/url/query-parameter-missing`
 -   **Title**: `Query parameter missing`
--   **Status**: `400`
+-   **Status**: `404`
 
 A required query parameter is missing. More info on what parameter specifically can be found in the `detail` property of the response.
 
@@ -35,7 +35,7 @@ A required query parameter is missing. More info on what parameter specifically 
 
 -   **Type:** `https://api.publiq.be/probs/url/query-parameter-invalid`
 -   **Title**: `Query parameter invalid`
--   **Status**: `400`
+-   **Status**: `404`
 
 The value of a given query parameter is invalid. More info on what parameter specifically can be found in the `detail` property of the response.
 
@@ -47,7 +47,7 @@ In some cases, depending on the API, this can also be returned when an invalid p
 
 -   **Type:** `https://api.publiq.be/probs/url/path-parameter-invalid`
 -   **Title**: `Path parameter invalid`
--   **Status**: `400`
+-   **Status**: `404`
 
 The value of a given path parameter (variable parts of a URL) is invalid. More info on what parameter specifically can be found in the `detail` property of the response.
 

--- a/toc.json
+++ b/toc.json
@@ -11,6 +11,11 @@
     },
     {
       "type": "item",
+      "title": "In request method",
+      "uri": "docs/type-method.md"
+    },
+    {
+      "type": "item",
       "title": "In request URL",
       "uri": "docs/type-url.md"
     },


### PR DESCRIPTION
### Added

- Added `https://api.publiq.be/probs/header/unsupported-media-type` for future use cases
- Added warnings to `https://api.publiq.be/probs/header/missing` and `https://api.publiq.be/probs/header/invalid` that more specific error types are preferred when possible

### Fixed

- Moved `https://api.publiq.be/probs/url/method-not-allowed` to `https://api.publiq.be/probs/method/not-allowed`, since the HTTP method is not part of the URL
- Changed query parameter errors from `400` to `404`, since query parameters are part of the identifier (URL) of a resource. So if they are incorrect, the error is technically `404` (URL Not Found) because the URL is invalid. The problem type & detail can of course still give further explanation, like that the query parameter is missing/invalid.

---

Some changes will have to be made in the UDB and UiTPAS APIs to change usages of these fixed error types/codes.

